### PR TITLE
Modify debian packaging for OVS library files

### DIFF
--- a/INSTALL.Debian.md
+++ b/INSTALL.Debian.md
@@ -42,7 +42,16 @@ You do not need to be the superuser to build the Debian packages.
    properly, dpkg-checkbuilddeps will exit without printing anything.
    If you forgot to install some dependencies, it will tell you which ones.
 
-4. Run:
+4. If you intend to install other applications that require Openvswitch
+   shared libraries, then set environment variable WITH_LIB_PACKAGE, e.g.
+       export WITH_LIB_PACKAGE=1
+   This will create additional packages (openvswitch-lib and
+   openvswitch-lib-dev) that contain Openvswitch shared libraries and
+   development files respectively. Note that with this option all OVS
+   binaries/utilities will use shared libraries instead of linking
+   against them statically.
+
+5. Run:
 
        `fakeroot debian/rules binary`
 
@@ -56,7 +65,7 @@ You do not need to be the superuser to build the Debian packages.
 
        `DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary`
 
-5. The generated .deb files will be in the parent directory of the
+6. The generated .deb files will be in the parent directory of the
    Open vSwitch source distribution.
 
 

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -14,6 +14,8 @@
 /openvswitch-ipsec
 /openvswitch-pki
 /openvswitch-switch
+/openvswitch-lib
+/openvswitch-lib-dev
 /openvswitch-switch.copyright
 /openvswitch-test
 /openvswitch-testcontroller

--- a/debian/automake.mk
+++ b/debian/automake.mk
@@ -50,6 +50,8 @@ EXTRA_DIST += \
 	debian/openvswitch-vtep.init \
 	debian/openvswitch-vtep.install \
 	debian/openvswitch-vtep.manpages \
+	debian/openvswitch-lib.install \
+	debian/openvswitch-lib-dev.install \
 	debian/ovs-monitor-ipsec \
 	debian/python-openvswitch.dirs \
 	debian/python-openvswitch.install \

--- a/debian/control
+++ b/debian/control
@@ -63,6 +63,24 @@ Description: Open vSwitch common components
  openvswitch-common provides components required by both openvswitch-switch
  and openvswitch-testcontroller.
 
+Package: openvswitch-lib
+Section: libs
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Open vSwitch shared libraries
+ Provides the Open vSwitch shared libraries used by the Open
+ vSwitch daemons and tools.
+
+Package: openvswitch-lib-dev
+Section: libdevel
+Architecture: linux-any
+Depends: ${shlibs:Depends}, ${misc:Depends}, openvswitch-lib (= ${binary:Version})
+Description: Open vSwitch OpenFlow development package (library, headers)
+ Provides static libraries and the openvswitch header
+ files needed to build an external application.
+
 Package: openvswitch-switch
 Architecture: linux-any
 Suggests: openvswitch-datapath-module

--- a/debian/openvswitch-lib-dev.install
+++ b/debian/openvswitch-lib-dev.install
@@ -1,0 +1,4 @@
+usr/include/*
+usr/lib/*/lib*.a
+usr/lib/*/lib*.la
+usr/lib/*/pkgconfig/*

--- a/debian/openvswitch-lib.install
+++ b/debian/openvswitch-lib.install
@@ -1,0 +1,1 @@
+usr/lib/*/lib*.so*

--- a/debian/rules
+++ b/debian/rules
@@ -29,6 +29,16 @@ else
 CFLAGS += -O2
 endif
 
+ENABLE_SHARED =
+INSTALL_LIB_DIR =
+EXCLUDE_LIB_PKG = --no-package=openvswitch-lib --no-package=openvswitch-lib-dev
+ifneq (,$(WITH_LIB_PACKAGE))
+ENABLE_SHARED = --enable-shared
+EXCLUDE_LIB_PKG =
+DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+INSTALL_LIB_DIR = --libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH)
+endif
+
 # Old versions of dpkg-buildflags do not understand --export=configure.
 # When dpkg-buildflags does not understand an option, it prints its full
 # --help output on stdout, so we have to avoid that here.
@@ -52,6 +62,7 @@ configure-stamp:
 	cd _debian && ( \
 		test -e Makefile || \
 		../configure --prefix=/usr --localstatedir=/var --enable-ssl \
+			$(INSTALL_LIB_DIR) $(ENABLE_SHARED) \
 			--sysconfdir=/etc --host=$(DEB_HOST_GNU_TYPE) CFLAGS="$(CFLAGS)" \
 			$(buildflags) $(DATAPATH_CONFIGURE_OPTS))
 	touch configure-stamp
@@ -123,8 +134,10 @@ install-arch: build-arch
 	dh_prep -s
 	dh_installdirs -s
 	$(MAKE) -C _debian DESTDIR=$(CURDIR)/debian/tmp install
+	# Temporary install of headers for library until headers are reorganized
+	find lib ofproto -name "*.h" -exec cp --parents -t $(CURDIR)/debian/tmp/usr/include/openvswitch/ {} \;
 	cp debian/openvswitch-switch.template debian/openvswitch-switch/usr/share/openvswitch/switch/default.template
-	dh_install -s
+	dh_install -s $(EXCLUDE_LIB_PKG)
 	dh_link -s
 
 # Must not depend on anything. This is to be called by
@@ -148,11 +161,11 @@ binary-common:
 	dh_python2
 	dh_perl
 	dh_makeshlibs
-	dh_installdeb
+	dh_installdeb $(EXCLUDE_LIB_PKG)
 	dh_shlibdeps
-	dh_gencontrol
+	dh_gencontrol $(EXCLUDE_LIB_PKG)
 	dh_md5sums
-	dh_builddeb
+	dh_builddeb $(EXCLUDE_LIB_PKG)
 binary-indep: install-indep
 	$(MAKE) -f debian/rules DH_OPTIONS=-i binary-common
 binary-arch: install-arch

--- a/lib/automake.mk
+++ b/lib/automake.mk
@@ -388,8 +388,8 @@ lib_libopenvswitch_la_SOURCES += lib/stream-nossl.c
 endif
 
 pkgconfig_DATA += \
-	$(srcdir)/lib/libopenvswitch.pc \
-	$(srcdir)/lib/libsflow.pc
+	lib/libopenvswitch.pc \
+	lib/libsflow.pc
 
 EXTRA_DIST += \
 	lib/dh1024.pem \

--- a/ofproto/automake.mk
+++ b/ofproto/automake.mk
@@ -60,7 +60,7 @@ ofproto_libofproto_la_LIBADD += ${PTHREAD_LIBS}
 endif
 
 pkgconfig_DATA += \
-	$(srcdir)/ofproto/libofproto.pc
+	ofproto/libofproto.pc
 
 # Distribute this generated file in order not to require Python at
 # build time if ofproto/ipfix.xml is not modified.

--- a/ovsdb/automake.mk
+++ b/ovsdb/automake.mk
@@ -36,7 +36,7 @@ ovsdb_libovsdb_la_CFLAGS = $(AM_CFLAGS)
 ovsdb_libovsdb_la_CPPFLAGS = $(AM_CPPFLAGS)
 
 pkgconfig_DATA += \
-	$(srcdir)/ovsdb/libovsdb.pc
+	ovsdb/libovsdb.pc
 
 MAN_FRAGMENTS += \
 	ovsdb/remote-active.man \


### PR DESCRIPTION
Introducing a new build option (environment variable
WITH_LIB_PACKAGE) to allow creating Debian packages for OVS
shared libraries. Two additional packages are created,
openvswitch-lib and openvswitch-lib-dev, containing the
shared libraries and development file respectively.
Other packages like openvswitch-common and openvswitch-lib
then become dependent on the -lib package.

Signed-off-by: Amit Bose <bose@noironetworks.com>